### PR TITLE
Fixed bug on freeze command

### DIFF
--- a/source/plugins/freeze.plugin.ts
+++ b/source/plugins/freeze.plugin.ts
@@ -13,14 +13,15 @@ export default class FreezePlugin extends Plugin.Plugin
 		new FreezeTaw(this, false)
 	]
 
+	/*
 	getMemberRole(guild: Discord.Guild): Discord.Role | undefined
 	{
 		return this.pluginManager.getPermissionRole( Plugin.Permission.User, guild );
-	}
+	}*/
 
 	getModRole(guild: Discord.Guild): Discord.Role | undefined
 	{
-		return this.pluginManager.getPermissionRole( Plugin.Permission.SuperMod, guild );
+		return this.pluginManager.getPermissionRole( Plugin.Permission.ChatMod, guild );
 	}
 }
 
@@ -51,10 +52,10 @@ class FreezeTaw extends Plugin.ChatCommand
 			return;
 		}
 
-		let memberRole = this.plugin.getMemberRole( message.guild );
+		//let memberRole = this.plugin.getMemberRole( message.guild );
 		let modRole = this.plugin.getModRole( message.guild );
 
-		if (!channel.manageable || !memberRole || !modRole)
+		if (!channel.manageable /*|| !memberRole*/ || !modRole)
 		{
 			if (this.freeze) channel.send( Lang.error );
 
@@ -66,7 +67,9 @@ class FreezeTaw extends Plugin.ChatCommand
 			if (this.freeze)
 			{
 				// Block members from writing, and allow mods to write
-				await channel.updateOverwrite( memberRole, { 'SEND_MESSAGES': false }, "channel freeze" );
+				await channel.updateOverwrite(message.guild.roles.everyone, {'SEND_MESSAGES': false}, "channel freeze");
+
+				//await channel.updateOverwrite( memberRole, { 'SEND_MESSAGES': false }, "channel freeze" );
 				await channel.updateOverwrite( modRole, { 'SEND_MESSAGES': true } );
 
 				channel.send( Lang.freeze );
@@ -74,7 +77,8 @@ class FreezeTaw extends Plugin.ChatCommand
 			else
 			{
 				// Reset member perm to neutral on unfreeze
-				await channel.updateOverwrite( memberRole, { 'SEND_MESSAGES': null } );
+				//await channel.updateOverwrite( memberRole, { 'SEND_MESSAGES': null } );
+				await channel.updateOverwrite(message.guild.roles.everyone, {'SEND_MESSAGES': null});
 
 				channel.send( Lang.unfreeze );
 			}

--- a/source/plugins/freeze.plugin.ts
+++ b/source/plugins/freeze.plugin.ts
@@ -92,11 +92,12 @@ class FreezeTaw extends Plugin.ChatCommand
 		}
 		catch(e)
 		{
+			let tempError = <Error> e; //Type assertion to get the compiler to understand e is an error
 
 			uncaughtError(
 				this.plugin.pluginManager.controlChannel,
 				(this.freeze) ? "freeze" : "unfreeze",
-				e,
+				tempError,
 				message.content
 			);
 

--- a/source/plugins/freeze.plugin.ts
+++ b/source/plugins/freeze.plugin.ts
@@ -13,15 +13,20 @@ export default class FreezePlugin extends Plugin.Plugin
 		new FreezeTaw(this, false)
 	]
 
-	/*
+	
 	getMemberRole(guild: Discord.Guild): Discord.Role | undefined
 	{
 		return this.pluginManager.getPermissionRole( Plugin.Permission.User, guild );
-	}*/
+	}
 
-	getModRole(guild: Discord.Guild): Discord.Role | undefined
+	getChatModRole(guild: Discord.Guild): Discord.Role | undefined
 	{
 		return this.pluginManager.getPermissionRole( Plugin.Permission.ChatMod, guild );
+	}
+
+	getSuperModRole(guild: Discord.Guild): Discord.Role | undefined
+	{
+		return this.pluginManager.getPermissionRole(Plugin.Permission.SuperMod, guild);
 	}
 }
 
@@ -52,10 +57,11 @@ class FreezeTaw extends Plugin.ChatCommand
 			return;
 		}
 
-		//let memberRole = this.plugin.getMemberRole( message.guild );
-		let modRole = this.plugin.getModRole( message.guild );
+		let memberRole = this.plugin.getMemberRole( message.guild );
+		let chatModRole = this.plugin.getChatModRole( message.guild );
+		let superModRole = this.plugin.getSuperModRole( message.guild );
 
-		if (!channel.manageable /*|| !memberRole*/ || !modRole)
+		if (!channel.manageable || !memberRole || !chatModRole || !superModRole)
 		{
 			if (this.freeze) channel.send( Lang.error );
 
@@ -68,16 +74,16 @@ class FreezeTaw extends Plugin.ChatCommand
 			{
 				// Block members from writing, and allow mods to write
 				await channel.updateOverwrite(message.guild.roles.everyone, {'SEND_MESSAGES': false}, "channel freeze");
-
-				//await channel.updateOverwrite( memberRole, { 'SEND_MESSAGES': false }, "channel freeze" );
-				await channel.updateOverwrite( modRole, { 'SEND_MESSAGES': true } );
+				await channel.updateOverwrite( memberRole, { 'SEND_MESSAGES': false }, "channel freeze" );
+				await channel.updateOverwrite( chatModRole, { 'SEND_MESSAGES': true } );
+				await channel.updateOverwrite( superModRole, { 'SEND_MESSAGES': true } );
 
 				channel.send( Lang.freeze );
 			}
 			else
 			{
 				// Reset member perm to neutral on unfreeze
-				//await channel.updateOverwrite( memberRole, { 'SEND_MESSAGES': null } );
+				await channel.updateOverwrite( memberRole, { 'SEND_MESSAGES': null } );
 				await channel.updateOverwrite(message.guild.roles.everyone, {'SEND_MESSAGES': null});
 
 				channel.send( Lang.unfreeze );


### PR DESCRIPTION
The freeze command locked chat mods out of the channel they were freezing and still permitted roleless users to send messages.
Now the command changes message permissions for everyone.